### PR TITLE
Closing the initial progress dialog when the torrent list has been loaded

### DIFF
--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -61,8 +61,8 @@ class TransmissionGUI(xbmcgui.WindowXMLDialog):
                 xbmcgui.Dialog().ok(_(2), message)
 
             return False
-        p.close()
         self.updateTorrents()
+        p.close()
         self.repeater = Repeater(1.0, self.updateTorrents)
         self.repeater.start()
     def updateTorrents(self):


### PR DESCRIPTION
The initial progress dialog is closed only when the list of torrents has been loaded. Useful when loading the list actually takes some time.
