### PR TITLE
Added close button to the torrent info dialog

### DIFF
--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -245,6 +245,7 @@ class TorrentInfoGUI(xbmcgui.WindowXMLDialog):
             self.close()
             pass
     def onClick(self, controlID):
-        pass
+        if controlID == 111:
+            self.close()
     def onFocus(self, controlID):
         pass

--- a/resources/skins/Default/720p/script-Transmission-details.xml
+++ b/resources/skins/Default/720p/script-Transmission-details.xml
@@ -133,5 +133,18 @@
 				</control>
 			</focusedlayout>
 		</control>
+		<control type="button" id="111">
+			<description>Close Window button</description>
+			<posx>850</posx>
+			<posy>0</posy>
+			<width>64</width>
+			<height>32</height>
+			<label>-</label>
+			<font>-</font>
+			<onclick>PreviousMenu</onclick>
+			<texturefocus>DialogCloseButton-focus.png</texturefocus>
+			<texturenofocus>DialogCloseButton.png</texturenofocus>
+			<visible>system.getbool(input.enablemouse)</visible>
+		</control>
 	</controls>
 </window>


### PR DESCRIPTION
A close button is added to the torrent info dialog. It is quite useful when the keyboard is not available.
