### PR TITLE
Fix and beautify output from TorrentReactor

### DIFF
--- a/resources/lib/search.py
+++ b/resources/lib/search.py
@@ -32,7 +32,7 @@ class Mininova(Search):
         return torrents
 class TPB(Search):
     def __init__(self):
-        self.search_uri = 'http://thepiratebay.se/search/%s/'
+        self.search_uri = 'http://thepiratebay.ac/search/%s/'
     def search(self, terms):
         torrents = []
         url = self.search_uri % '+'.join(terms.split(' '))


### PR DESCRIPTION
re.findall is looking for "seeders" while in fact the output shows "seeder", this is now working. Also, item.title.text has a prefix showing the category (eg. "[Movies - DVD-R]") which makes it uneasy to read in the results dialog, so this has been stripped off. Finally, the results are being rev sorted by seeds to promote the most popular entries.
