### PR TITLE
Add ability to enable temporary speed limits on video playback

### DIFF
--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -41,7 +41,10 @@
     <string id="1002">Port</string>
     <string id="1003">User</string>
     <string id="1004">Password</string>
-    <string id="1005">Stop all torrents on video playback</string>
+    <string id="1005">Action on video playback</string>
+    <string id="1006">None</string>
+    <string id="1007">Pause all torrents</string>
+    <string id="1008">Enable Temporary Speed Limits</string>
 
     <!-- Errors -->
     <string id="9000">An unexpected error occurred</string>

--- a/resources/lib/common.py
+++ b/resources/lib/common.py
@@ -12,7 +12,7 @@ def get_settings():
         'port': __settings__.getSetting('rpc_port'),
         'user': __settings__.getSetting('rpc_user'),
         'password': __settings__.getSetting('rpc_password'),
-        'stop_all_on_playback': __settings__.getSetting('stop_all_on_playback')
+        'action_on_playback': __settings__.getSetting('action_on_playback')
     }
     return params
 

--- a/resources/lib/player.py
+++ b/resources/lib/player.py
@@ -21,13 +21,18 @@ class SubstitutePlayer(xbmc.Player):
 
     def onPlayBackStarted(self):
         self.refreshSettings()
-        if self.active and xbmc.Player().isPlayingVideo():
-            self.stopAllTorrents()
+        if self.mode != '0' and xbmc.Player().isPlayingVideo():
+            if self.mode == '1':
+                self.stopAllTorrents()
+            elif self.mode == '2':
+                self.enableSpeedLimit()
 
     def onPlayBackStopped(self):
         self.refreshSettings()
-        if self.active:
+        if self.mode == '1':
             self.startAllTorrents()
+        elif self.mode == '2':
+            self.disableSpeedLimit()
 
     def startAllTorrents(self):
         if self.transmission:
@@ -41,10 +46,18 @@ class SubstitutePlayer(xbmc.Player):
             for tid, torrent in torrents.iteritems():
                 self.transmission.stop(tid)
 
+    def enableSpeedLimit(self):
+        if self.transmission:
+            self.transmission.set_session(alt_speed_enabled=True)
+
+    def disableSpeedLimit(self):
+        if self.transmission:
+            self.transmission.set_session(alt_speed_enabled=False)
+
     def refreshSettings(self):
         settings = common.get_settings()
         if settings != self.prev_settings:
-            self.active = (settings['stop_all_on_playback'] == 'true')
+            self.mode = settings['action_on_playback']
             try:
                 self.transmission = common.get_rpc_client()
             except:

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,5 +5,5 @@
     <setting id="rpc_port" type="number" label="1002" default="9091" />
     <setting id="rpc_user" type="text" label="1003" default="" />
     <setting id="rpc_password" type="text" option="hidden" label="1004" default="" />
-    <setting id="stop_all_on_playback" type="bool" label="1005" default="false" />
+    <setting id="action_on_playback" type="enum" label="1005" lvalues="1006|1007|1008" />
 </settings>


### PR DESCRIPTION
Very small change which adds an option to turn on the Temporary Speed Limits, a.k.a. turtle mode, when video is playing.
