### PR TITLE
Minor fixes and added 1337x, YTS, LimeTorrents and EZTV to the search.

### DIFF
--- a/resources/language/Catalan/strings.po
+++ b/resources/language/Catalan/strings.po
@@ -109,6 +109,10 @@ msgctxt "#32207"
 msgid "Search LimeTorrents"
 msgstr ""
 
+msgctxt "#32208"
+msgid "Search EZTV"
+msgstr ""
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr ""

--- a/resources/language/Catalan/strings.po
+++ b/resources/language/Catalan/strings.po
@@ -97,6 +97,18 @@ msgctxt "#32204"
 msgid "Search KickassTorrents"
 msgstr ""
 
+msgctxt "#32205"
+msgid "Search 1337x"
+msgstr ""
+
+msgctxt "#32206"
+msgid "Search YTS"
+msgstr ""
+
+msgctxt "#32207"
+msgid "Search LimeTorrents"
+msgstr ""
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr ""

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -111,7 +111,19 @@ msgctxt "#32204"
 msgid "Search KickassTorrents"
 msgstr ""
 
-#empty strings from id 32205 to 32289
+msgctxt "#32205"
+msgid "Search 1337x"
+msgstr ""
+
+msgctxt "#32206"
+msgid "Search YTS"
+msgstr ""
+
+msgctxt "#32207"
+msgid "Search LimeTorrents"
+msgstr ""
+
+#empty strings from id 32208 to 32289
 
 msgctxt "#32290"
 msgid "Searching..."

--- a/resources/language/English/strings.po
+++ b/resources/language/English/strings.po
@@ -123,7 +123,11 @@ msgctxt "#32207"
 msgid "Search LimeTorrents"
 msgstr ""
 
-#empty strings from id 32208 to 32289
+msgctxt "#32208"
+msgid "Search EZTV"
+msgstr ""
+
+#empty strings from id 32209 to 32289
 
 msgctxt "#32290"
 msgid "Searching..."

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -122,7 +122,11 @@ msgctxt "#32207"
 msgid "Search LimeTorrents"
 msgstr "LimeTorrents durchsuchen"
 
-# empty strings from id 208 to 289
+msgctxt "#32208"
+msgid "Search EZTV"
+msgstr "EZTV durchsuchen"
+
+# empty strings from id 209 to 289
 msgctxt "#32290"
 msgid "Searching..."
 msgstr "Suche läuft..."

--- a/resources/language/German/strings.po
+++ b/resources/language/German/strings.po
@@ -110,7 +110,19 @@ msgctxt "#32204"
 msgid "Search KickassTorrents"
 msgstr "KickassTorrents durchsuchen"
 
-# empty strings from id 205 to 289
+msgctxt "#32205"
+msgid "Search 1337x"
+msgstr "1337x durchsuchen"
+
+msgctxt "#32206"
+msgid "Search YTS"
+msgstr "YTS durchsuchen"
+
+msgctxt "#32207"
+msgid "Search LimeTorrents"
+msgstr "LimeTorrents durchsuchen"
+
+# empty strings from id 208 to 289
 msgctxt "#32290"
 msgid "Searching..."
 msgstr "Suche läuft..."

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -109,6 +109,10 @@ msgctxt "#32207"
 msgid "Search LimeTorrents"
 msgstr ""
 
+msgctxt "#32208"
+msgid "Search EZTV"
+msgstr ""
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr ""

--- a/resources/language/Hungarian/strings.po
+++ b/resources/language/Hungarian/strings.po
@@ -97,6 +97,18 @@ msgctxt "#32204"
 msgid "Search KickassTorrents"
 msgstr ""
 
+msgctxt "#32205"
+msgid "Search 1337x"
+msgstr ""
+
+msgctxt "#32206"
+msgid "Search YTS"
+msgstr ""
+
+msgctxt "#32207"
+msgid "Search LimeTorrents"
+msgstr ""
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr ""

--- a/resources/language/Korean/strings.po
+++ b/resources/language/Korean/strings.po
@@ -109,6 +109,10 @@ msgctxt "#32207"
 msgid "Search LimeTorrents"
 msgstr ""
 
+msgctxt "#32208"
+msgid "Search EZTV"
+msgstr ""
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr ""

--- a/resources/language/Korean/strings.po
+++ b/resources/language/Korean/strings.po
@@ -97,6 +97,18 @@ msgctxt "#32204"
 msgid "Search KickassTorrents"
 msgstr ""
 
+msgctxt "#32205"
+msgid "Search 1337x"
+msgstr ""
+
+msgctxt "#32206"
+msgid "Search YTS"
+msgstr ""
+
+msgctxt "#32207"
+msgid "Search LimeTorrents"
+msgstr ""
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr ""

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -97,6 +97,18 @@ msgctxt "#32204"
 msgid "Search KickassTorrents"
 msgstr "Искать на KickassTorrents"
 
+msgctxt "#32205"
+msgid "Search 1337x"
+msgstr "Искать на 1337x"
+
+msgctxt "#32206"
+msgid "Search YTS"
+msgstr "Искать на YTS"
+
+msgctxt "#32207"
+msgid "Search LimeTorrents"
+msgstr "Искать на LimeTorrents"
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr "Поиск..."

--- a/resources/language/Russian/strings.po
+++ b/resources/language/Russian/strings.po
@@ -109,6 +109,10 @@ msgctxt "#32207"
 msgid "Search LimeTorrents"
 msgstr "Искать на LimeTorrents"
 
+msgctxt "#32208"
+msgid "Search EZTV"
+msgstr "Искать на EZTV"
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr "Поиск..."

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -109,6 +109,10 @@ msgctxt "#32207"
 msgid "Search LimeTorrents"
 msgstr "Buscar en LimeTorrents"
 
+msgctxt "#32208"
+msgid "Search EZTV"
+msgstr "Buscar en EZTV"
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr "Buscando..."

--- a/resources/language/Spanish/strings.po
+++ b/resources/language/Spanish/strings.po
@@ -97,6 +97,18 @@ msgctxt "#32204"
 msgid "Search KickassTorrents"
 msgstr "Buscar en KickassTorrents"
 
+msgctxt "#32205"
+msgid "Search 1337x"
+msgstr "Buscar en 1337x"
+
+msgctxt "#32206"
+msgid "Search YTS"
+msgstr "Buscar en YTS"
+
+msgctxt "#32207"
+msgid "Search LimeTorrents"
+msgstr "Buscar en LimeTorrents"
+
 msgctxt "#32290"
 msgid "Searching..."
 msgstr "Buscando..."

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -117,6 +117,7 @@ class TransmissionGUI(xbmcgui.WindowXMLDialog):
                 (_(32205), search.L337x),
                 (_(32206), search.YTS),
                 (_(32207), search.Lime),
+                (_(32208), search.EZTV),
             ]
             selected = xbmcgui.Dialog().select(_(32000), [i[0] for i in engines])
             if selected < 0:

--- a/resources/lib/gui.py
+++ b/resources/lib/gui.py
@@ -114,6 +114,9 @@ class TransmissionGUI(xbmcgui.WindowXMLDialog):
                 (_(32202), search.TPB),
                 (_(32203), search.Mininova),
                 (_(32204), search.Kickass),
+                (_(32205), search.L337x),
+                (_(32206), search.YTS),
+                (_(32207), search.Lime),
             ]
             selected = xbmcgui.Dialog().select(_(32000), [i[0] for i in engines])
             if selected < 0:

--- a/resources/lib/search.py
+++ b/resources/lib/search.py
@@ -1,6 +1,8 @@
+import sys
 import re
 import socket
-from urllib2 import urlopen, URLError
+from urllib2 import urlopen, Request, URLError, HTTPError
+from urllib import quote, quote_plus
 from BeautifulSoup import BeautifulSoup, BeautifulStoneSoup
 
 socket.setdefaulttimeout(15)
@@ -16,7 +18,7 @@ class Mininova(Search):
         self.search_uri = 'http://www.mininova.org/rss/%s'
     def search(self, terms):
         torrents = []
-        url = self.search_uri % '+'.join(terms.split(' '))
+        url = self.search_uri % quote_plus(terms)
         f = urlopen(url)
         soup = BeautifulStoneSoup(f.read())
         for item in soup.findAll('item'):
@@ -30,14 +32,17 @@ class Mininova(Search):
         return torrents
 class TPB(Search):
     def __init__(self):
-        self.search_uris = ['http://thepiratebay.se/search/%s/',
+        self.user_agent = 'Mozilla/5.0'
+        self.search_uris = ['https://thepiratebay.se/search/%s/',
                             'http://pirateproxy.net/search/%s/']
     def search(self, terms):
         torrents = []
         f = None
-        for url in [u % '+'.join(terms.split(' ')) for u in self.search_uris]:
+        for url in [u % quote(terms) for u in self.search_uris]:
+            req = Request(url)
+            req.add_header('User-Agent', self.user_agent)
             try:
-                f = urlopen(url)
+                f = urlopen(req)
                 break
             except URLError:
                 continue
@@ -63,18 +68,103 @@ class Kickass(Search):
         self.search_uri = 'http://kickass.to/usearch/%s/?field=seeders&sorder=desc&rss=1'
     def search(self, terms):
         torrents = []
-        url = self.search_uri % '+'.join(terms.split(' '))
+        url = self.search_uri % quote_plus(terms)
+        try:
+            f = urlopen(url)
+            soup = BeautifulStoneSoup(f.read())
+            for item in soup.findAll('item'):
+                torrents.append({
+                    'url': item.enclosure['url'],
+                    'name': item.title.text,
+                    'seeds': int(item.find('torrent:seeds').text),
+                    'leechers': int(item.find('torrent:peers').text),
+                })
+        except HTTPError as e:
+            if e.code == 404:
+                pass
+            else:
+                raise
+        return torrents
+class L337x(Search):
+    def __init__(self):
+        self.uri_prefix = 'http://1337x.to'
+        self.search_uri = self.uri_prefix + '/sort-search/%s/seeders/desc/1/'
+    def search(self, terms):
+        torrents = []
+        url = self.search_uri % quote_plus(terms)
+        f = urlopen(url)
+        soup = BeautifulStoneSoup(f.read())
+        for details in soup.findAll('a', {'href': re.compile('^/torrent/')}):
+            div = details.findNext('div')
+            seeds = int(div.text)
+            div = div.findNext('div')
+            f_link = urlopen(self.uri_prefix + details['href'])
+            soup_link = BeautifulStoneSoup(f_link.read())
+            link = soup_link.find('a', {'href': re.compile('^magnet:')})
+            if not link:
+                continue
+            torrents.append({
+                'url': link['href'],
+                'name': details.text,
+                'seeds': seeds,
+                'leechers': int(div.text),
+            })
+        return torrents
+class YTS(Search):
+    def __init__(self):
+        self.search_uri = 'http://yts.to/rss/%s/all/all/0'
+    def search(self, terms):
+        torrents = []
+        url = self.search_uri % quote(terms, '')
         f = urlopen(url)
         soup = BeautifulStoneSoup(f.read())
         for item in soup.findAll('item'):
+            item_quality = item.link.text.rpartition('_')[2]
+            item_f = urlopen(item.link.text)
+            item_soup = BeautifulStoneSoup(item_f.read())
+            qualities = [s.text.strip() for s in
+                         item_soup.findAll('span', {'class': re.compile('^tech-quality')})]
+            q_index = qualities.index(item_quality)
+            span = item_soup.findAll('span', {'title': 'Peers and Seeds'})[q_index]
+            ps_pos = len(span.parent.contents) - 1
+            ps = span.parent.contents[ps_pos].split('/')
             torrents.append({
                 'url': item.enclosure['url'],
                 'name': item.title.text,
-                'seeds': int(item.find('torrent:seeds').text),
-                'leechers': int(item.find('torrent:peers').text),
+                'seeds': int(ps[1]),
+                'leechers': int(ps[0])
+            })
+        return torrents
+class Lime(Search):
+    def __init__(self):
+        self.search_uri = 'https://www.limetorrents.cc/searchrss/%s/'
+    def search(self, terms):
+        torrents = []
+        url = self.search_uri % quote(terms)
+        f = urlopen(url)
+        soup = BeautifulStoneSoup(f.read())
+        for item in soup.findAll('item'):
+            (seeds, leechers) = re.findall('Seeds: (\d+) , Leechers (\d+)', item.description.text)[0]
+            torrents.append({
+                'url': item.enclosure['url'],
+                'name': item.title.text,
+                'seeds': int(seeds),
+                'leechers': int(leechers)
             })
         return torrents
 
 if __name__ == '__main__':
-    s = TPB()
-    results = s.search('zettai')
+    sites = [Mininova(), TPB(), Kickass(), L337x(), YTS(), Lime()]
+    terms = 'transmission'
+    if len(sys.argv) > 1:
+        terms = sys.argv[1]
+    print 'Searching for "' + terms + '"'
+    for site in sites:
+        print site.__class__.__name__.center(79, '=')
+        torrents = site.search(terms)
+        print 'Total found = ' + str(len(torrents))
+        for counter, file in enumerate(torrents):
+            print '[{:3},{:3}] {:33} "{:33}"'.format(file['seeds'], file['leechers'],
+                                                     file['name'][:33], file['url'][:33])
+            if counter == 4:
+                break


### PR DESCRIPTION
- A few minor fixes (e.g. TPB wasn't working without an "actual" user-agent string)
- Four new top torrent sites (according to [TorrentFreak](https://torrentfreak.com/top-popular-torrent-sites-2015-150104/)): **1337x**, **YTS**, **LimeTorrents** and **EZTV**
- Improved test for the search module when called directly from the command line (e.g. `python search.py`_`whatever`_)
